### PR TITLE
bugfix: Fix error on splitting the filename and ext part of files having multiple dots

### DIFF
--- a/src/ConfigurationTransform.Test/ConfigTransformManagerTest.cs
+++ b/src/ConfigurationTransform.Test/ConfigTransformManagerTest.cs
@@ -23,6 +23,7 @@ namespace ConfigurationTransform.Test
         const string TransformAppConfig = @"app.MockBuild.config";
         const string TransformWithoutConfigExtension = @"app.MockBuild";
         const string FileWith3Dots = @"mockfile.mockMiddle.mock";
+        const string FileWithMoreDots = @"file.with.more.dots.config";
 
         const string BuildMock = @"MockBuild";
 
@@ -56,6 +57,21 @@ namespace ConfigurationTransform.Test
 
             //Act
             ConfigTransformManager.GetTransformConfigName(sourceConfigName, buildConfigurationName);
+        }
+
+        [TestMethod]
+        public void GetTransformConfigName_WhenMoreDots_Success()
+        {
+            //Arrange
+            const string sourceConfigName = FileWithMoreDots;
+            const string buildConfigurationName = BuildMock;
+            const string expected = @"file.with.more.dots.MockBuild.config";
+
+            //Act
+            var actual = ConfigTransformManager.GetTransformConfigName(sourceConfigName, buildConfigurationName);
+
+            //Assert
+            Assert.AreEqual(expected, actual);
         }
 
         [TestMethod]

--- a/src/ConfigurationTransform.Test/ConfigurationTransform.Test.csproj
+++ b/src/ConfigurationTransform.Test/ConfigurationTransform.Test.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ConfigTransformManagerTest.cs" />
     <Compile Include="ProjectItemExtensionsTest.cs" />
     <Compile Include="ProjectItemsExtensionsTest.cs" />
+    <Compile Include="VsProjectXmlTransformTest.cs" />
     <Compile Include="VsServicesTest.cs" />
     <Compile Include="XmlTransformTest.cs" />
   </ItemGroup>

--- a/src/ConfigurationTransform.Test/VsProjectXmlTransformTest.cs
+++ b/src/ConfigurationTransform.Test/VsProjectXmlTransformTest.cs
@@ -1,0 +1,54 @@
+﻿using GolanAvraham.ConfigurationTransform.Services;
+using GolanAvraham.ConfigurationTransform.Transform;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConfigurationTransform.Test
+{
+    [TestClass]
+    public class VsProjectXmlTransformTest
+    {
+        const string FileWithMoreDots = "file.with.more.dots.config";
+
+        private VsProjectXmlTransform vsProjectXmlTransform;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var vsSerivces = new Mock<IVsServices>();
+            vsProjectXmlTransform = new VsProjectXmlTransform(vsSerivces.Object);
+        }
+
+        [TestMethod]
+        public void GetTargetTransformArgs_WhenMoreDotsConfigName_Success()
+        {
+            //Arrange
+            var configName = FileWithMoreDots;
+            var relativePrefix = @"..\my.common";
+            var expected = new TargetTransformArgs {
+                ConfigExt = "config",
+                Transform = @"..\my.common\file.with.more.dots.$(Configuration).config",
+                Source = @"..\my.common\file.with.more.dots.config",
+                Destination = @"$(OutputPath)file.with.more.dots.config",
+                Condition = @"Exists('..\my.common\file.with.more.dots.$(Configuration).config')"
+            };
+
+            //Act
+            var args = vsProjectXmlTransform.GetTargetTransformArgs(configName, relativePrefix, true);
+
+            //Assert
+            Assert.IsNotNull(args);
+            Assert.AreEqual(expected.Condition, args.Condition);
+            Assert.AreEqual(expected.ConfigExt, args.ConfigExt);
+            Assert.AreEqual(expected.Destination, args.Destination);
+            Assert.AreEqual(expected.Source, args.Source);
+            Assert.AreEqual(expected.Transform, args.Transform);
+        }
+
+    }
+}

--- a/src/ConfigurationTransform/Transform/ConfigTransformManager.cs
+++ b/src/ConfigurationTransform/Transform/ConfigTransformManager.cs
@@ -234,11 +234,11 @@ namespace GolanAvraham.ConfigurationTransform.Transform
 
         public static string GetTransformConfigName(string sourceConfigName, string buildConfigurationName)
         {
-            var spilterIndex = sourceConfigName.LastIndexOf('.');
-            if(spilterIndex < 0)
+            var spliterIndex = sourceConfigName.LastIndexOf('.');
+            if(spliterIndex < 0)
                 throw new NotSupportedException(sourceConfigName);
 
-            var dependentConfig = $"{sourceConfigName.Substring(0, spilterIndex)}.{buildConfigurationName}.{sourceConfigName.Substring(spilterIndex + 1)}";
+            var dependentConfig = $"{sourceConfigName.Substring(0, spliterIndex)}.{buildConfigurationName}.{sourceConfigName.Substring(spliterIndex + 1)}";
             return dependentConfig;
         }
 

--- a/src/ConfigurationTransform/Transform/ConfigTransformManager.cs
+++ b/src/ConfigurationTransform/Transform/ConfigTransformManager.cs
@@ -234,9 +234,11 @@ namespace GolanAvraham.ConfigurationTransform.Transform
 
         public static string GetTransformConfigName(string sourceConfigName, string buildConfigurationName)
         {
-            var configSplit = sourceConfigName.Split('.');
-            if (configSplit.Length < 2) throw new NotSupportedException(sourceConfigName);
-            var dependentConfig = $"{configSplit[0]}.{buildConfigurationName}.{configSplit[1]}";
+            var spilterIndex = sourceConfigName.LastIndexOf('.');
+            if(spilterIndex < 0)
+                throw new NotSupportedException(sourceConfigName);
+
+            var dependentConfig = $"{sourceConfigName.Substring(0, spilterIndex)}.{buildConfigurationName}.{sourceConfigName.Substring(spilterIndex + 1)}";
             return dependentConfig;
         }
 

--- a/src/ConfigurationTransform/Transform/ConfigTransformManager.cs
+++ b/src/ConfigurationTransform/Transform/ConfigTransformManager.cs
@@ -234,11 +234,11 @@ namespace GolanAvraham.ConfigurationTransform.Transform
 
         public static string GetTransformConfigName(string sourceConfigName, string buildConfigurationName)
         {
-            var spliterIndex = sourceConfigName.LastIndexOf('.');
-            if(spliterIndex < 0)
+            var splitterIndex = sourceConfigName.LastIndexOf('.');
+            if(splitterIndex < 0)
                 throw new NotSupportedException(sourceConfigName);
 
-            var dependentConfig = $"{sourceConfigName.Substring(0, spliterIndex)}.{buildConfigurationName}.{sourceConfigName.Substring(spliterIndex + 1)}";
+            var dependentConfig = $"{sourceConfigName.Substring(0, splitterIndex)}.{buildConfigurationName}.{sourceConfigName.Substring(splitterIndex + 1)}";
             return dependentConfig;
         }
 

--- a/src/ConfigurationTransform/Transform/VsProjectXmlTransform.cs
+++ b/src/ConfigurationTransform/Transform/VsProjectXmlTransform.cs
@@ -162,12 +162,12 @@ namespace GolanAvraham.ConfigurationTransform.Transform
         public TargetTransformArgs GetTargetTransformArgs(string anyConfigName, string relativePrefix = null,
             bool transformConfigIsLink = false)
         {
-            var spliterIndex = anyConfigName.LastIndexOf('.');
-            if (spliterIndex < 0)
+            var splitterIndex = anyConfigName.LastIndexOf('.');
+            if (splitterIndex < 0)
                 throw new NotSupportedException(anyConfigName);
 
-            var configName = anyConfigName.Substring(0, spliterIndex);
-            var configExt = anyConfigName.Substring(spliterIndex + 1);
+            var configName = anyConfigName.Substring(0, splitterIndex);
+            var configExt = anyConfigName.Substring(splitterIndex + 1);
 
             if (relativePrefix != null)
             {

--- a/src/ConfigurationTransform/Transform/VsProjectXmlTransform.cs
+++ b/src/ConfigurationTransform/Transform/VsProjectXmlTransform.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -162,8 +163,8 @@ namespace GolanAvraham.ConfigurationTransform.Transform
             bool transformConfigIsLink = false)
         {
             var spliterIndex = anyConfigName.LastIndexOf('.');
-            if (spilterIndex < 0)
-                throw new NotSupportedException(sourceConfigName);
+            if (spliterIndex < 0)
+                throw new NotSupportedException(anyConfigName);
 
             var configName = anyConfigName.Substring(0, spliterIndex);
             var configExt = anyConfigName.Substring(spliterIndex + 1);

--- a/src/ConfigurationTransform/Transform/VsProjectXmlTransform.cs
+++ b/src/ConfigurationTransform/Transform/VsProjectXmlTransform.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using GolanAvraham.ConfigurationTransform.Services;
 
@@ -160,9 +161,12 @@ namespace GolanAvraham.ConfigurationTransform.Transform
         public TargetTransformArgs GetTargetTransformArgs(string anyConfigName, string relativePrefix = null,
             bool transformConfigIsLink = false)
         {
-            var configSplit = anyConfigName.Split('.');
-            var configName = configSplit[0];
-            var configExt = configSplit[1];
+            var spliterIndex = anyConfigName.LastIndexOf('.');
+            if (spilterIndex < 0)
+                throw new NotSupportedException(sourceConfigName);
+
+            var configName = anyConfigName.Substring(0, spliterIndex);
+            var configExt = anyConfigName.Substring(spliterIndex + 1);
 
             if (relativePrefix != null)
             {


### PR DESCRIPTION
Fix error on splitting the filename and ext part of transform files having multiple dots, such like "Foo.bar.config", it should create the file named "Foo.bar.Debug.config", not the error one "Foo.Debug.bar".