### PR TITLE
Added support for VS2019.

### DIFF
--- a/src/ConfigurationTransform/source.extension.vsixmanifest
+++ b/src/ConfigurationTransform/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
         <Tags>app.config;Build;Configuration;diff;Team Development;Transform;XDT</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,15.0]" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[11.0, 17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -21,6 +21,6 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Support for versions older than 2015 will need to be dropped in the future to ensure it stays compatible with VS2019. [This link](https://docs.microsoft.com/en-us/visualstudio/extensibility/synchronously-autoloaded-extensions?view=vs-2019) explains the changes that must be made in the future.